### PR TITLE
colour-simplify

### DIFF
--- a/docs/online/draw.js
+++ b/docs/online/draw.js
@@ -364,7 +364,7 @@ function gridClick(evt){
 		// grid was already activated, user wants to change color
 		g.setAttribute('data-old','1');
 
-		colourchoose([],grid,(colour)=>{
+		colourchoose(["#eaeaea","#4c4c4c","#096"],grid,(colour)=>{
 			grid=colour;
 			document.body.style.setProperty('--grid-color',grid);
 			document.getElementById('grid').setAttribute('data-old','2');

--- a/docs/online/draw.js
+++ b/docs/online/draw.js
@@ -361,59 +361,16 @@ function gridClick(evt){
 	evt.preventDefault();
 	var g=document.getElementById('grid');
 	if(g.getAttribute('data-old')=='0'){
-		// cancel the chooser for pen colour if it was open
-		if(document.getElementById('pen').getAttribute('data-old')=='close'){
-			document.getElementById('pen').setAttribute('data-old','true');
-		}
-		// cancel the chooser for background colour if it was open
-		if(document.getElementById('bg-color').getAttribute('data-open')=='true'){
-			document.getElementById('bg-color').setAttribute('data-open','false');
-		}
-
 		// grid was already activated, user wants to change color
 		g.setAttribute('data-old','1');
 
-		// set colour palette for grid
-		document.getElementById('colour-a').style.backgroundColor="#eaeaea";
-		document.getElementById('colour-b').style.backgroundColor="#4c4c4c";
-		document.getElementById('colour-c').style.backgroundColor="#096";
-
-		// hide unused colours
-		document.getElementById('colour-d').style.display=
-		document.getElementById('colour-e').style.display=
-		document.getElementById('colour-f').style.display="none";
-
-		document.getElementById('colour-a').onclick=
-		document.getElementById('colour-b').onclick=
-		document.getElementById('colour-c').onclick=
-		document.getElementById('white').onclick=
-		document.getElementById('black').onclick=
-		(evt)=>{
-			grid=rgb2hex(window.getComputedStyle(evt.target).backgroundColor);
+		colourchoose([],grid,(colour)=>{
+			grid=colour;
 			document.body.style.setProperty('--grid-color',grid);
-			document.getElementById('colours-wrapper').style.display="none";
 			document.getElementById('grid').setAttribute('data-old','2');
 			saved=false;
-		};
+		});
 
-		// remove action listener from unused buttons
-		document.getElementById('colour-d').onclick=
-		document.getElementById('colour-e').onclick=
-		document.getElementById('colour-f').onclick=()=>{};
-
-		document.getElementById('chooser').onclick=()=>{
-			colorchooser.value=rgb2hex(grid);
-			colorchooser.onchange=function(evt){
-				grid=colorchooser.value;
-				document.body.style.setProperty('--grid-color',grid);
-				saved=false;
-			};
-			document.getElementById('colours-wrapper').style.display="none";
-			document.getElementById('grid').setAttribute('data-old','2');
-			evt.preventDefault();
-			colorchooser.click();
-		}
-		document.getElementById('colours-wrapper').style.display="block";
 		g.checked=true;
 	}else if(g.getAttribute('data-old')=='1'){
 		// dismiss colour chooser

--- a/docs/online/draw.js
+++ b/docs/online/draw.js
@@ -1,12 +1,12 @@
 var canvas; // main canvas for drawing
 var context; // 2d drawing context
 var image; // an array of former activePath's
-var activePath; // object storing information on how to recreate a certain drawing feature
-var redoStack; // array storing former activePath's that have been undone to be redone
+var activePath; // object storing information on how to recreate the current drawing feature
+var redoStack; // array storing former activePath's that have been undone
 var penColor; // the current colour used to draw as a string (e.g. "#ffffff")
-var bgColor; // the current colour used for the background as a css value (e.g)
+var bgColor; // the current colour used for the background as a string (e.g. "#006633")
 var penWidth; // width used to draw with the pen tool
-var eraseWidth; // width used to erase something; usually >penWidth
+var eraseWidth; // width used to erase something
 var colorchooser; // DOM element: <input type="color">
 var drawing; // boolean, wether the user is drawing at the moment
 var prevX; // the previous x coordinate when drawing
@@ -42,7 +42,7 @@ function setupHandlers(){
 	// check when to stop scrolling and/or drawing
 	var end=()=>{
 		if(drawing){
-			mouseup();
+			canvas.onmouseup();
 		}else if(scrolling!=-1){
 			scrollStop();
 		}
@@ -69,9 +69,9 @@ function setupHandlers(){
 	document.body.ontouchcancel=document.onmouseup;
 	// handlers for the canvas
 	// mouse handlers
-	canvas.onmousedown=mousedown;
-	canvas.onmousemove=mousemove;
-	canvas.onmouseup=mouseup;
+	canvas.onmousedown=drawStart;
+	canvas.onmousemove=drawMove;
+	canvas.onmouseup=drawStop;
 	// touch handlers
 	canvas.ontouchstart=(evt)=>{
 		canvas.onmousedown(evt.touches[0]);
@@ -208,44 +208,6 @@ function saveImg(){
 	});
 }
 
-function down(){
-	if(height<document.documentElement.clientHeight){
-		height=document.documentElement.clientHeight;
-	}
-	if(scrolled>=getScrollBarMax()){
-		resize(height+100);
-		saved=false;
-	}
-	scrolled=getScrollBarMax();
-	document.getElementById('scroll').style.top=(scrolled*document.documentElement.clientHeight/height)+"px";
-	document.body.style.backgroundPosition=`top ${-scrolled}px left 0`;
-	repaintAll();
-}
-
-function undo(){
-	if(image.length>0){
-		redoStack.push(image.pop());
-		saved=false;
-		document.getElementById('redo').style.filter="";
-	}
-	repaintAll();
-	if(image.length<=0){
-		document.getElementById('undo').style.filter="brightness(50%)";
-	}
-}
-
-function redo(){
-	if(redoStack.length>0){
-		image.push(redoStack.pop());
-		saved=false;
-		document.getElementById('undo').style.filter="";
-	}
-	repaintAll();
-	if(redoStack.length<=0){
-		document.getElementById('redo').style.filter="brightness(50%)";
-	}
-}
-
 function repaintAll(){
 	if(typeof canvas=='undefined'||typeof context=='undefined'){
 		console.warn("canvas not defined");
@@ -288,105 +250,6 @@ function repaintAll(){
 		}
 		// draw the current path
 		context.stroke();
-	}
-}
-
-function penClick(){
-	var pen=document.getElementById('pen');
-	if(pen.getAttribute('data-old')=='true'){
-		// pen was already activated, user wants to change color
-		pen.setAttribute('data-old','close');
-
-		colourchoose(["#dd0622","#f8ba00","#2676cc","#0cfc04","#b41c74","#ccd4d4"],context.strokeStyle,(colour)=>{
-			pen.setAttribute('data-old','true');
-			penColor=colour;
-			document.body.style.setProperty("--pen-color",penColor);
-			saved=false;
-		});
-	}else if(pen.getAttribute('data-old')=='close'){
-		// dismiss colour chooser
-		document.getElementById('colours-wrapper').style.display="none";
-		pen.setAttribute('data-old','true');
-	}else{
-		// only activate pen
-		pen.setAttribute('data-old','true');
-		document.getElementById('stroke').value=penWidth;
-		document.getElementById('erase-cur').style.display="none";
-		document.getElementById('canvas').style.cursor="url(pen.cur),crosshair";
-	}
-}
-
-function eraseClick(){
-	var pen=document.getElementById('pen');
-	// dismiss colour chooser if it was open
-	if(pen.getAttribute('data-old')=='close'){
-		document.getElementById('colours-wrapper').style.display="none";
-	}
-	pen.setAttribute('data-old','false');
-	document.getElementById('stroke').value=eraseWidth;
-	document.getElementById('erase-cur').style.display="block";
-	document.body.style.setProperty("--erase-size",eraseWidth+"px");
-	document.getElementById('canvas').style.cursor="none";
-}
-
-function strokeChange(){
-	var stroke=document.getElementById('stroke').value;
-	if(document.getElementById('erase').checked){
-		eraseWidth=stroke;
-		document.body.style.setProperty("--erase-size",eraseWidth+"px");
-	}else{
-		penWidth=stroke;
-	}
-	saved=false;
-}
-
-function bgColorClick(){
-	var btn=document.getElementById('bg-color');
-	if(btn.getAttribute('data-open')=='true'){
-		// dismiss colour chooser
-		document.getElementById('colours-wrapper').style.display="none";
-		btn.setAttribute('data-open','true');
-	}else{
-		colourchoose(["#063","#343434","#2C4474","#FCD4A3"],document.body.style.backgroundColor,(colour)=>{
-			bgColor=colour;
-			document.body.style.backgroundColor=bgColor;
-			document.getElementById('bg-color').setAttribute('data-open','false');
-			saved=false;
-		});
-		btn.setAttribute('data-open','true');
-	}
-}
-
-function gridClick(evt){
-	evt.preventDefault();
-	var g=document.getElementById('grid');
-	if(g.getAttribute('data-old')=='0'){
-		// grid was already activated, user wants to change color
-		g.setAttribute('data-old','1');
-
-		colourchoose(["#eaeaea","#4c4c4c","#096"],grid,(colour)=>{
-			grid=colour;
-			document.body.style.setProperty('--grid-color',grid);
-			document.getElementById('grid').setAttribute('data-old','2');
-			saved=false;
-		});
-
-		g.checked=true;
-	}else if(g.getAttribute('data-old')=='1'){
-		// dismiss colour chooser
-		document.getElementById('colours-wrapper').style.display="none";
-		g.setAttribute('data-old','2');
-		g.checked=true;
-	}else if(g.getAttribute('data-old')=='2'){
-		// deactivate grid
-		document.body.classList.remove('grid');
-		g.setAttribute('data-old','3');
-		g.checked=false;
-	}else if(g.getAttribute('data-old')=='3'){
-		// activate grid
-		document.body.classList.add('grid');
-		g.setAttribute('data-old','0');
-		g.checked=true;
 	}
 }
 

--- a/docs/online/draw.js
+++ b/docs/online/draw.js
@@ -143,6 +143,11 @@ function setup(){
 	resize(document.documentElement.clientHeight);
 	context.lineWidth=penWidth;
 	context.clearRect(0,0,canvas.width,canvas.height);
+	// check for colorchooser support
+	if(!colourInputSupport()){
+		// the browser based colour chooser is not supported
+		document.getElementById('chooser').style.display="none";
+	}
 	setupHandlers();
 }
 

--- a/docs/online/draw.js
+++ b/docs/online/draw.js
@@ -294,60 +294,15 @@ function repaintAll(){
 function penClick(){
 	var pen=document.getElementById('pen');
 	if(pen.getAttribute('data-old')=='true'){
-		// cancel the chooser for background colour if it was open
-		if(document.getElementById('bg-color').getAttribute('data-open')=='true'){
-			document.getElementById('bg-color').setAttribute('data-open','false');
-		}
-		// cancel the chooser for grid colour if it was open
-		if(document.getElementById('grid').getAttribute('data-open')=='1'){
-			document.getElementById('grid').setAttribute('data-open','0');
-		}
-
 		// pen was already activated, user wants to change color
 		pen.setAttribute('data-old','close');
 
-		// set colour palette for pen
-		document.getElementById('colour-a').style.backgroundColor="#dd0622";
-		document.getElementById('colour-b').style.backgroundColor="#f8ba00";
-		document.getElementById('colour-c').style.backgroundColor="#2676cc";
-		document.getElementById('colour-d').style.backgroundColor="#0cfc04";
-		document.getElementById('colour-e').style.backgroundColor="#b41c74";
-		document.getElementById('colour-f').style.backgroundColor="#ccd4d4";
-
-		// show additional colours
-		document.getElementById('colour-c').style.display=
-		document.getElementById('colour-d').style.display=
-		document.getElementById('colour-e').style.display=
-		document.getElementById('colour-f').style.display="initial";
-
-		document.getElementById('colour-a').onclick=
-		document.getElementById('colour-b').onclick=
-		document.getElementById('colour-c').onclick=
-		document.getElementById('colour-d').onclick=
-		document.getElementById('colour-e').onclick=
-		document.getElementById('colour-f').onclick=
-		document.getElementById('white').onclick=
-		document.getElementById('black').onclick=
-		(evt)=>{
+		colourchoose(["#dd0622","#f8ba00","#2676cc","#0cfc04","#b41c74","#ccd4d4"],context.strokeStyle,(colour)=>{
 			pen.setAttribute('data-old','true');
-			penColor=rgb2hex(window.getComputedStyle(evt.target).backgroundColor);
+			penColor=colour;
 			document.body.style.setProperty("--pen-color",penColor);
 			saved=false;
-			document.getElementById('colours-wrapper').style.display="none";
-		};
-
-		document.getElementById('chooser').onclick=()=>{
-			colorchooser.value=context.strokeStyle;
-			colorchooser.onchange=function(evt){
-				penColor=colorchooser.value;
-				document.body.style.setProperty("--pen-color",penColor);
-				saved=false;
-			};
-			pen.setAttribute('data-old','true');
-			document.getElementById('colours-wrapper').style.display="none";
-			colorchooser.click();
-		}
-		document.getElementById('colours-wrapper').style.display="block";
+		});
 	}else if(pen.getAttribute('data-old')=='close'){
 		// dismiss colour chooser
 		document.getElementById('colours-wrapper').style.display="none";

--- a/docs/online/draw.js
+++ b/docs/online/draw.js
@@ -392,61 +392,13 @@ function bgColorClick(){
 		document.getElementById('colours-wrapper').style.display="none";
 		btn.setAttribute('data-open','true');
 	}else{
-		// cancel the chooser for pen colour if it was open
-		if(document.getElementById('pen').getAttribute('data-old')=='close'){
-			document.getElementById('pen').setAttribute('data-old','true');
-		}
-		// cancel the chooser for grid colour if it was open
-		if(document.getElementById('grid').getAttribute('data-open')=='1'){
-			document.getElementById('grid').setAttribute('data-open','0');
-		}
-
-		// set colour palette for background
-		document.getElementById('colour-a').style.backgroundColor="#063";
-		document.getElementById('colour-b').style.backgroundColor="#343434";
-		document.getElementById('colour-c').style.backgroundColor="#2C4474";
-		document.getElementById('colour-d').style.backgroundColor="#FCD4A3";
-
-		// show additional colours
-		document.getElementById('colour-c').style.display=
-		document.getElementById('colour-d').style.display="initial";
-
-		// hide unused colours
-		document.getElementById('colour-e').style.display=
-		document.getElementById('colour-f').style.display="none";
-
-		document.getElementById('colour-a').onclick=
-		document.getElementById('colour-b').onclick=
-		document.getElementById('colour-c').onclick=
-		document.getElementById('colour-d').onclick=
-		document.getElementById('white').onclick=
-		document.getElementById('black').onclick=
-		(evt)=>{
-			bgColor=rgb2hex(window.getComputedStyle(evt.target).backgroundColor);
+		colourchoose(["#063","#343434","#2C4474","#FCD4A3"],document.body.style.backgroundColor,(colour)=>{
+			bgColor=colour;
 			document.body.style.backgroundColor=bgColor;
 			document.getElementById('bg-color').setAttribute('data-open','false');
 			saved=false;
-			document.getElementById('colours-wrapper').style.display="none";
-		};
-
-		// remove action listener from unused buttons
-		document.getElementById('colour-e').onclick=
-		document.getElementById('colour-f').onclick=()=>{};
-
-		document.getElementById('chooser').onclick=()=>{
-			colorchooser.value=rgb2hex(document.body.style.backgroundColor);
-			colorchooser.onchange=function(evt){
-				document.body.style.backgroundColor=colorchooser.value;
-				bgColor=colorchooser.value;
-				saved=false;
-			};
-			document.getElementById('bg-color').setAttribute('data-open','false');
-			document.getElementById('colours-wrapper').style.display="none";
-			colorchooser.click();
-		}
-
-		document.getElementById('bg-color').setAttribute('data-open','true');
-		document.getElementById('colours-wrapper').style.display="block";
+		});
+		btn.setAttribute('data-open','true');
 	}
 }
 

--- a/docs/online/index.html
+++ b/docs/online/index.html
@@ -29,12 +29,12 @@
 		</aside>
 		<div id="colours-wrapper">
 			<div id="colours">
-				<input type="button" id="colour-a" />
-				<input type="button" id="colour-b" />
-				<input type="button" id="colour-c" />
-				<input type="button" id="colour-d" />
-				<input type="button" id="colour-e" />
-				<input type="button" id="colour-f" />
+				<input type="button" id="colour-0" />
+				<input type="button" id="colour-1" />
+				<input type="button" id="colour-2" />
+				<input type="button" id="colour-3" />
+				<input type="button" id="colour-4" />
+				<input type="button" id="colour-5" />
 				<input type="button" id="white" />
 				<input type="button" id="black" />
 				<input type="button" id="chooser" />

--- a/docs/online/lib.js
+++ b/docs/online/lib.js
@@ -41,6 +41,56 @@ function toggleFullscreen() {
 	}
 }
 
+function colorchoose(colours,current,handler){
+	// cancel the chooser for pen colour if it was open
+	if(document.getElementById('pen').getAttribute('data-old')=='close'){
+		document.getElementById('pen').setAttribute('data-old','true');
+	}
+	// cancel the chooser for background colour if it was open
+	if(document.getElementById('bg-color').getAttribute('data-open')=='true'){
+		document.getElementById('bg-color').setAttribute('data-open','false');
+	}
+	// cancel the chooser for grid colour if it was open
+	if(document.getElementById('grid').getAttribute('data-open')=='1'){
+		document.getElementById('grid').setAttribute('data-open','0');
+	}
+
+	for(let i=0;i<6;i++){
+		if(i>colours.length){
+			// hide this one
+			document.getElementById('colour-'+i).style.display="none";
+			// remove action handler
+			document.getElementById('colour-'+i).onclick=()=>{};
+		}else{
+			// show colour
+			document.getElementById('colour-'+i).style.display="initial";
+			document.getElementById('colour-'+i).style.backgroundColor=colours[i];
+			// set action handler
+			document.getElementById('colour-'+i).onclick=(evt)=>{
+				let colour=rgb2hex(window.getComputedStyle(evt.target).backgroundColor);
+				handler(colour);
+			};
+		}
+	}
+	document.getElementById('white').onclick=
+	document.getElementById('black').onclick=(evt)=>{
+		let colour=rgb2hex(window.getComputedStyle(evt.target).backgroundColor);
+		handler(colour);
+	};
+
+	document.getElementById('chooser').onclick=()=>{
+		colorchooser.value=rgb2hex(current);
+		colorchooser.onchange=function(evt){
+			handler(colorchoose.value);
+		};
+		document.getElementById('colours-wrapper').style.display="none";
+		colorchooser.click();
+	}
+
+	// show colour bar
+	document.getElementById('colours-wrapper').style.display="block";
+}
+
 Array.prototype.max = function() {
 	return Math.max.apply(null, this);
 };

--- a/docs/online/lib.js
+++ b/docs/online/lib.js
@@ -2,6 +2,13 @@ function getScrollBarMax(){
 	return height-document.documentElement.clientHeight;
 }
 
+function colourInputSupport(){
+	let i=document.createElement("input");
+	i.setAttribute("type","color");
+	// if this type is not supported, the browser will reset the type to "text"
+	return i.type!=="text";
+}
+
 function rgb2hex(rgb){
 	rgb = rgb.match(/^rgba?[\s+]?\([\s+]?(\d+)[\s+]?,[\s+]?(\d+)[\s+]?,[\s+]?(\d+)[\s+]?/i);
 	return (rgb && rgb.length === 4) ? "#" +

--- a/docs/online/lib.js
+++ b/docs/online/lib.js
@@ -59,8 +59,6 @@ function colorchoose(colours,current,handler){
 		if(i>colours.length){
 			// hide this one
 			document.getElementById('colour-'+i).style.display="none";
-			// remove action handler
-			document.getElementById('colour-'+i).onclick=()=>{};
 		}else{
 			// show colour
 			document.getElementById('colour-'+i).style.display="initial";

--- a/docs/online/lib.js
+++ b/docs/online/lib.js
@@ -41,7 +41,7 @@ function toggleFullscreen() {
 	}
 }
 
-function colorchoose(colours,current,handler){
+function colourchoose(colours,current,handler){
 	// cancel the chooser for pen colour if it was open
 	if(document.getElementById('pen').getAttribute('data-old')=='close'){
 		document.getElementById('pen').setAttribute('data-old','true');
@@ -65,6 +65,7 @@ function colorchoose(colours,current,handler){
 			document.getElementById('colour-'+i).style.backgroundColor=colours[i];
 			// set action handler
 			document.getElementById('colour-'+i).onclick=(evt)=>{
+				document.getElementById('colours-wrapper').style.display="none";
 				let colour=rgb2hex(window.getComputedStyle(evt.target).backgroundColor);
 				handler(colour);
 			};
@@ -72,6 +73,7 @@ function colorchoose(colours,current,handler){
 	}
 	document.getElementById('white').onclick=
 	document.getElementById('black').onclick=(evt)=>{
+		document.getElementById('colours-wrapper').style.display="none";
 		let colour=rgb2hex(window.getComputedStyle(evt.target).backgroundColor);
 		handler(colour);
 	};
@@ -79,7 +81,7 @@ function colorchoose(colours,current,handler){
 	document.getElementById('chooser').onclick=()=>{
 		colorchooser.value=rgb2hex(current);
 		colorchooser.onchange=function(evt){
-			handler(colorchoose.value);
+			handler(colorchooser.value);
 		};
 		document.getElementById('colours-wrapper').style.display="none";
 		colorchooser.click();

--- a/docs/online/mouse.js
+++ b/docs/online/mouse.js
@@ -1,4 +1,6 @@
-function mousedown(evt){
+// canvas drawing handlers
+
+function drawStart(evt){
 	context.beginPath();
 	if(document.getElementById("erase").checked){
 		context.globalCompositeOperation="destination-out";
@@ -32,7 +34,7 @@ function mousedown(evt){
 	context.stroke();
 }
 
-function mousemove(evt){
+function drawMove(evt){
 	if(drawing){
 		context.moveTo(prevX,prevY-scrolled);
 		prevX=evt.clientX-canvas.offsetLeft;
@@ -50,7 +52,7 @@ function mousemove(evt){
 	style.setProperty("--erase-y",evt.clientY+"px");
 }
 
-function mouseup(evt){
+function drawStop(evt){
 	if(drawing!==true) return;
 	if(typeof evt!=='undefined'&&activePath!=null){
 		// this is a real mouse handler call and not a delegation
@@ -76,6 +78,8 @@ function mouseup(evt){
 	drawing=false;
 }
 
+// scrolling handlers
+
 var scrolling=-1;
 function scrollStart(evt){
 	scrolling=evt.clientY;
@@ -94,4 +98,142 @@ function scrollMove(evt){
 
 function scrollStop(){
 	scrolling=-1;
+}
+
+// toolbar handlers
+
+function penClick(){
+	var pen=document.getElementById('pen');
+	if(pen.getAttribute('data-old')=='true'){
+		// pen was already activated, user wants to change color
+		pen.setAttribute('data-old','close');
+
+		colourchoose(["#dd0622","#f8ba00","#2676cc","#0cfc04","#b41c74","#ccd4d4"],context.strokeStyle,(colour)=>{
+			pen.setAttribute('data-old','true');
+			penColor=colour;
+			document.body.style.setProperty("--pen-color",penColor);
+			saved=false;
+		});
+	}else if(pen.getAttribute('data-old')=='close'){
+		// dismiss colour chooser
+		document.getElementById('colours-wrapper').style.display="none";
+		pen.setAttribute('data-old','true');
+	}else{
+		// only activate pen
+		pen.setAttribute('data-old','true');
+		document.getElementById('stroke').value=penWidth;
+		document.getElementById('erase-cur').style.display="none";
+		document.getElementById('canvas').style.cursor="url(pen.cur),crosshair";
+	}
+}
+
+
+function eraseClick(){
+	var pen=document.getElementById('pen');
+	// dismiss colour chooser if it was open
+	if(pen.getAttribute('data-old')=='close'){
+		document.getElementById('colours-wrapper').style.display="none";
+	}
+	pen.setAttribute('data-old','false');
+	document.getElementById('stroke').value=eraseWidth;
+	document.getElementById('erase-cur').style.display="block";
+	document.body.style.setProperty("--erase-size",eraseWidth+"px");
+	document.getElementById('canvas').style.cursor="none";
+}
+
+function bgColorClick(){
+	var btn=document.getElementById('bg-color');
+	if(btn.getAttribute('data-open')=='true'){
+		// dismiss colour chooser
+		document.getElementById('colours-wrapper').style.display="none";
+		btn.setAttribute('data-open','true');
+	}else{
+		colourchoose(["#063","#343434","#2C4474","#FCD4A3"],document.body.style.backgroundColor,(colour)=>{
+			bgColor=colour;
+			document.body.style.backgroundColor=bgColor;
+			document.getElementById('bg-color').setAttribute('data-open','false');
+			saved=false;
+		});
+		btn.setAttribute('data-open','true');
+	}
+}
+
+function gridClick(evt){
+	evt.preventDefault();
+	var g=document.getElementById('grid');
+	if(g.getAttribute('data-old')=='0'){
+		// grid was already activated, user wants to change color
+		g.setAttribute('data-old','1');
+		colourchoose(["#eaeaea","#4c4c4c","#096"],grid,(colour)=>{
+			grid=colour;
+			document.body.style.setProperty('--grid-color',grid);
+			document.getElementById('grid').setAttribute('data-old','2');
+			saved=false;
+		});
+		g.checked=true;
+	}else if(g.getAttribute('data-old')=='1'){
+		// dismiss colour chooser
+		document.getElementById('colours-wrapper').style.display="none";
+		g.setAttribute('data-old','2');
+		g.checked=true;
+	}else if(g.getAttribute('data-old')=='2'){
+		// deactivate grid
+		document.body.classList.remove('grid');
+		g.setAttribute('data-old','3');
+		g.checked=false;
+	}else if(g.getAttribute('data-old')=='3'){
+		// activate grid
+		document.body.classList.add('grid');
+		g.setAttribute('data-old','0');
+		g.checked=true;
+	}
+}
+
+function undo(){
+	if(image.length>0){
+		redoStack.push(image.pop());
+		saved=false;
+		document.getElementById('redo').style.filter="";
+	}
+	repaintAll();
+	if(image.length<=0){
+		document.getElementById('undo').style.filter="brightness(50%)";
+	}
+}
+
+function redo(){
+	if(redoStack.length>0){
+		image.push(redoStack.pop());
+		saved=false;
+		document.getElementById('undo').style.filter="";
+	}
+	repaintAll();
+	if(redoStack.length<=0){
+		document.getElementById('redo').style.filter="brightness(50%)";
+	}
+}
+
+function strokeChange(){
+	var stroke=document.getElementById('stroke').value;
+	if(document.getElementById('erase').checked){
+		eraseWidth=stroke;
+		document.body.style.setProperty("--erase-size",eraseWidth+"px");
+	}else{
+		penWidth=stroke;
+	}
+	saved=false;
+}
+
+function down(){
+	if(height<document.documentElement.clientHeight){
+		height=document.documentElement.clientHeight;
+	}
+	if(scrolled>=getScrollBarMax()){
+		resize(height+100);
+		saved=false;
+	}
+	scrolled=getScrollBarMax();
+	document.getElementById('scroll').style.top=(scrolled*document.documentElement.clientHeight/height)+"px";
+	document.body.style.backgroundPosition=`top ${-scrolled}px left 0`;
+	repaintAll();
 }


### PR DESCRIPTION
The colour bar management in code was greatly simplified. Also did some refactoring. For older browsers which do not support the HTML5 input type `color`, the colour wheel will not be shown because it is not available.

Overall the length of `draw.js`was decreased to make it more readable. All files are now shorter than 300 lines.